### PR TITLE
fix: add tailwind and prettier as peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,16 +22,17 @@
 		"build": "rimraf ./lib && tsc"
 	},
 	"dependencies": {
-		"prettier": "^2.1.2",
-		"tailwind-classes-sorter": "^0.2.5",
-		"tailwindcss": "^1.8.13"
+		"tailwind-classes-sorter": "^0.2.5"
 	},
 	"devDependencies": {
 		"@types/node": "^14.14.8",
 		"rimraf": "^3.0.2",
+		"prettier": "^2.1.2",
+		"tailwindcss": "^1.8.13",
 		"typescript": "^4.0.5"
 	},
 	"peerDependencies": {
-		"prettier": "^2.0.0"
+		"prettier": "^2.0.0",
+		"tailwindcss": "*"
 	}
 }


### PR DESCRIPTION
Both prettier and Tailwind were listed as `dependencies`, causing them to be installed regardless of the versions defined in the consuming project. 

This ensures they are listed as `peerDependencies`, avoiding installing both Tailwind 1.8.13 and Tailwind 2.1.0, etc.