### PR TITLE
Typo Fix: marco --> macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Supports
 - CSS (@apply directive)
 - ReactJS (JSX, TSX)
 - VueJS
-- [twin.marco](https://github.com/ben-rogerson/twin.macro)
+- [twin.macro](https://github.com/ben-rogerson/twin.macro)
 
 **Go from this:**
 


### PR DESCRIPTION
I just noticed a typo in the readme, & wanted to correct it.