### PR TITLE
fix: skip task if the options are undefined

### DIFF
--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -16,7 +16,7 @@ export default (twClassesSorter: TWClassesSorter) => ({
 			options
 		)
 
-		if (!twClassesSorter) {
+		if (!twClassesSorter || typeof options === 'undefined') {
 			return ast
 		}
 


### PR DESCRIPTION
ref: #25 

Jest inline snapshot testing fails when prettier-plugin-tailwind is installed.
Because the argument `options` is `undefined` when ran by jest.

This skip running the task when `options` is `undefined`.
